### PR TITLE
Avoid frozen string error

### DIFF
--- a/lib/supplier_payments/payment_file.rb
+++ b/lib/supplier_payments/payment_file.rb
@@ -20,7 +20,7 @@ module SupplierPayments
 
     def to_s
       records.map { |record|
-        "#{ record.to_s.force_encoding("ISO-8859-15") }\r\n"
+        "#{ record.to_s.dup.force_encoding("ISO-8859-15") }\r\n"
       }.join
     end
 

--- a/lib/supplier_payments/payment_file/records.rb
+++ b/lib/supplier_payments/payment_file/records.rb
@@ -87,11 +87,11 @@ module SupplierPayments
       def field_value(field)
         case field
         when :reserved!
-          ""
+          +""
         when :transaction_code!
-          transaction_code
+          transaction_code.dup
         else
-          send(field).to_s
+          send(field).to_s.dup
         end
       end
     end


### PR DESCRIPTION
This PR fixes an issue which appears in Ruby 2.7.

Read more about Frozen in this blog post: https://freelancing-gods.com/2017/07/27/an-introduction-to-frozen-string-literals.html