### PR TITLE
Mention Bankgirot in gemspec description

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![CircleCI](https://circleci.com/gh/barsoom/supplier_payments.svg?style=svg)](https://circleci.com/gh/barsoom/supplier_payments)
 
-Library for making BGC supplier payment files.
+Library for making Bankgirot supplier payment files, _Leverantörsbetalningar_.
 
 ## Documentation
 
-* [Swedish documentation](http://www.bgc.se/globalassets/dokument/tekniska-manualer/leverantorsbetalningar_tekniskmanual_sv.pdf)
-* [English documentation](http://www.bgc.se/globalassets/dokument/tekniska-manualer/supplierpayments_leverantorsbetalningar_technicalmanual_en.pdf)
+* På svenska: ["Leverantörsbetalningar, teknisk manual"](http://www.bgc.se/globalassets/dokument/tekniska-manualer/leverantorsbetalningar_tekniskmanual_sv.pdf) (PDF)
+* In English: ["Supplier Payments (Leverantörsbetalningar), technical manual"](http://www.bgc.se/globalassets/dokument/tekniska-manualer/supplierpayments_leverantorsbetalningar_technicalmanual_en.pdf) (PDF)

--- a/supplier_payments.gemspec
+++ b/supplier_payments.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |s|
   s.authors     = ["Andreas Alin"]
   s.email       = ["andreas.alin@gmail.com"]
   s.homepage    = "https://github.com/barsoom/supplier_payments"
-  s.summary     = %q{Supplier payment files}
-  s.description = %q{This gem should help you parse and generate supplier payment files that will work with BGC.}
+  s.summary     = %q{Parse and generate supplier payment files for Bankgirot.}
+  s.description = %q{Parse and generate supplier payment files for "Leverantörsbetalningar" in Bankgirot.}
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
This PR prepares a **new description and summary** field in gemspec.

The name used before was BGC (Bankgirocentralen) and their new name is Bankgirot.